### PR TITLE
feat(Handdling protection Error): used the jwt middle ware from jwt n…

### DIFF
--- a/nodeapi/server.js
+++ b/nodeapi/server.js
@@ -31,9 +31,17 @@ app.use(bodyParser.json());
 app.use(cookieParser())
 app.use(expressValidator());
 
+
 // use routes as middleware
 app.use('/', postRoutes);
 app.use('/', authRoutes);
+
+// jwt error handling middleware
+app.use(function (err, req, res, next) {
+   if (err.name === 'UnauthorizedError') {
+      res.status(401).json({ error: 'Unauthorized ! . please insert Token  (Bearer--token--' })
+   }
+});
 
 const PORT = process.env.PORT || 8080;
 app.listen(PORT, () => {


### PR DESCRIPTION
…pm site

- used the  express Jwt middleware from jwt website

- customised the middleware to echo error message in the api

- NOte: to authorize user to the protected Enpoint, copy the token key, use int the header section of the Api tester (post man)

- select authorized

- when pasting the token make sure u start with (Bearer ---Token---)